### PR TITLE
Fix GitHub Pages CI for Bun

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,18 +29,16 @@ jobs:
         with:
           lfs: true
 
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: oven-sh/setup-bun@v2
         with:
-          node-version: "20.x"
-          registry-url: "https://registry.npmjs.org"
+          bun-version: "1.3.4"
 
       # Install dependencies
       - name: Install Dependencies
-        run: npm ci
+        run: bun install --frozen-lockfile
 
       - name: Build
-        run: npm run build
+        run: bun run build
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "bun@1.3.4",
   "scripts": {
     "dev": "npm run watch",
     "watch": "rtgl sites watch -p 3000 -o dist",


### PR DESCRIPTION
## Summary
- switch the GitHub Pages build job from npm to Bun
- install dependencies with `bun install --frozen-lockfile`
- declare the package manager in `package.json`

## Verification
- bun install --frozen-lockfile
- bun run build
